### PR TITLE
コメント機能のバグを修正

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,12 +1,14 @@
 class CommentsController < ApplicationController
   before_action :authenticate_user!
   before_action :set_oogiri, only: [:create, :destroy]
+  before_action :set_field, only: [:create, :destroy]
   def create
     @comment = Comment.new(comment_params)
     if @comment.save
       redirect_to field_oogiri_path(@oogiri.field, @oogiri)
     else
-      render :oogiris/show
+      @comments = Comment.where(oogiri_id: @oogiri.id)
+      render "oogiris/show"
     end
   end
 
@@ -23,5 +25,9 @@ class CommentsController < ApplicationController
 
   def set_oogiri
     @oogiri = Oogiri.find(params[:oogiri_id])
+  end
+
+  def set_field
+    @field = Field.find(params[:field_id])
   end
 end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -2,5 +2,5 @@ class Comment < ApplicationRecord
   belongs_to :user
   belongs_to :oogiri
 
-  validates :content, presence: true, length: { maximum: 200 }
+  validates :content, presence: true, length: { maximum: 255 }
 end

--- a/app/views/oogiris/show.html.erb
+++ b/app/views/oogiris/show.html.erb
@@ -61,6 +61,7 @@
 <hr class="mb-0">
 <div class="card-body">
   <%= form_with(model: [@field, @oogiri, @comment], local: true) do |f| %>
+    <%= render 'shared/error_messages', model: f.object %>
     <div class="form-group small">
       <%= f.label :content, "コメントする" %><br />
       <%= f.text_area :content, autofocus: true, class: "col-sm-12 px-1", rows: 4 %>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -220,3 +220,5 @@ ja:
       field:
       oogiri:
         content: 回答
+      comment:
+        content: コメント


### PR DESCRIPTION
# What
コメント機能のエラーレンダリングがちゃんと機能してなかった。
例えばコメントを空で投稿したり、文字数200を超えてていたりすると、
通常: そのページに止まり注意文をフォームに表示する
今回: エラーが発生
となっていたのでそれを改善した。
原因は、ページのrenderが正しい書き方じゃなかったのと、必要なインスタンス変数が渡せていなかったこと。
エラーの発生元は文字数超過だったので、200->255にした。

# Why
エラーが出るのはいけないことだから